### PR TITLE
feat: 可視範囲にコメントが流れるように修正

### DIFF
--- a/bookmarklets/google_slide_usertool_stream.js
+++ b/bookmarklets/google_slide_usertool_stream.js
@@ -1,16 +1,17 @@
 const broadcastChannel = new BroadcastChannel('comment_channel');
 
 const addComment = (comment) => {
-  console.log(comment);
-
   const element = document.createElement("p");
   element.innerText = comment;
 
   const boxElement = document.querySelector('.punch-present-iframe').contentWindow.document.querySelector('.punch-viewer-content');
   boxElement.appendChild(element);
 
-  const elementTop = (boxElement.clientHeight - element.clientHeight) * Math.random();
-  console.log(elementTop);
+  const beltPerContainer = 0.12;
+  const containerHeight = boxElement.clientHeight * (1 - beltPerContainer);
+
+  const random = Math.random();
+  const elementTop = ((containerHeight - element.clientHeight) * random);
 
   const moveUnit = 5;
   const windowWidth = document.body.clientWidth;


### PR DESCRIPTION
もともとコメント要素のTop位置がRandomの値によって隠れてしまうパターンがあったので修正した

![image](https://user-images.githubusercontent.com/4104038/164753299-70682d3f-e5d9-443d-b3d8-41542d66ae56.png)

プラスでこういう帯が出てくると隠れてしまうパターンがあるので割合を固定し可視範囲にのみコメントが流れるようにした
